### PR TITLE
fixing oldNode and newNode for substeps in NodeStatus childChanged function

### DIFF
--- a/lib/NodeStatus.js
+++ b/lib/NodeStatus.js
@@ -79,9 +79,13 @@ NodeStatus.childChanged = function(node, childStatus, childArgIndex=null) {
     newNode.content = childStatus.newNode;
     oldNode.content = childStatus.oldNode;
     substeps.map(step => {
-      let newStep = clone(node, false);
-      newStep.content = step;
-      return newStep;
+      let newNode = clone(node, false);
+      let oldNode = clone(node, false);
+      newNode.content = step.newNode;
+      oldNode.content = step.oldNode;
+      step.newNode = newNode;
+      step.oldNode = oldNode;
+      return step;
     });
   }
   else if ((NodeType.isOperator(node) || NodeType.isFunction(node) &&
@@ -89,18 +93,26 @@ NodeStatus.childChanged = function(node, childStatus, childArgIndex=null) {
     newNode.args[childArgIndex] = childStatus.newNode;
     oldNode.args[childArgIndex] = childStatus.oldNode;
     substeps.map(step => {
-      let newStep = clone(node, false);
-      newStep.args[childArgIndex] = step;
-      return newStep;
+      let newNode = clone(node, false);
+      let oldNode = clone(node, false);
+      newNode.args[childArgIndex] = step.newNode;
+      oldNode.args[childArgIndex] = step.oldNode;
+      step.newNode = newNode;
+      step.oldNode = oldNode;
+      return step;
     });
   }
   else if (NodeType.isUnaryMinus(node)) {
     newNode.args[0] = childStatus.newNode;
     oldNode.args[0] = childStatus.oldNode;
     substeps.map(step => {
-      let newStep = clone(node, false);
-      newStep.args[0] = step;
-      return newStep;
+      let newNode = clone(node, false);
+      let oldNode = clone(node, false);
+      newNode.args[0] = step.newNode;
+      oldNode.args[0] = step.oldNode;
+      step.newNode = newNode;
+      step.oldNode = oldNode;
+      return step;
     });
   }
   else {

--- a/lib/NodeStatus.js
+++ b/lib/NodeStatus.js
@@ -76,15 +76,15 @@ NodeStatus.childChanged = function(node, childStatus, childArgIndex=null) {
   }
 
   if (NodeType.isParenthesis(node)) {
-    newNode.content = childStatus.newNode;
     oldNode.content = childStatus.oldNode;
+    newNode.content = childStatus.newNode;
     substeps.map(step => {
-      let newNode = clone(node, false);
       let oldNode = clone(node, false);
-      newNode.content = step.newNode;
+      let newNode = clone(node, false);
       oldNode.content = step.oldNode;
-      step.newNode = newNode;
+      newNode.content = step.newNode;
       step.oldNode = oldNode;
+      step.newNode = newNode;
       return step;
     });
   }
@@ -93,25 +93,25 @@ NodeStatus.childChanged = function(node, childStatus, childArgIndex=null) {
     newNode.args[childArgIndex] = childStatus.newNode;
     oldNode.args[childArgIndex] = childStatus.oldNode;
     substeps.map(step => {
-      let newNode = clone(node, false);
       let oldNode = clone(node, false);
-      newNode.args[childArgIndex] = step.newNode;
+      let newNode = clone(node, false);
       oldNode.args[childArgIndex] = step.oldNode;
-      step.newNode = newNode;
+      newNode.args[childArgIndex] = step.newNode;
       step.oldNode = oldNode;
+      step.newNode = newNode;
       return step;
     });
   }
   else if (NodeType.isUnaryMinus(node)) {
-    newNode.args[0] = childStatus.newNode;
     oldNode.args[0] = childStatus.oldNode;
+    newNode.args[0] = childStatus.newNode;
     substeps.map(step => {
-      let newNode = clone(node, false);
       let oldNode = clone(node, false);
-      newNode.args[0] = step.newNode;
+      let newNode = clone(node, false);
       oldNode.args[0] = step.oldNode;
-      step.newNode = newNode;
+      newNode.args[0] = step.newNode;
       step.oldNode = oldNode;
+      step.newNode = newNode;
       return step;
     });
   }


### PR DESCRIPTION
This was assigning the substep to a `newNode`, rather than updating the substeps `newNode` and `oldNode`