### PR TITLE
add pre-commit hook to run tests & linter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,7 @@ Please report unacceptable behavior to mathsteps@socratic.org
 
 - Make sure you properly unit test your changes.
 - Run tests with `npm test`
+- Install Git hooks with `npm run setup-hooks`. This will add a pre-commit hook which makes sure tests are passing and the code is eslint-compliant.
 - If you want to see what the expression tree looks like at any point
   in the code, for debugging, you can log `node` as an expression string
   (e.g. '2x + 5') with `console.log(print(node))`, and you can log the full

--- a/lib/simplifyExpression/stepThrough.js
+++ b/lib/simplifyExpression/stepThrough.js
@@ -109,7 +109,6 @@ function step(node) {
 // Removes unnecessary parens throughout the steps.
 // TODO: Ideally this would happen in NodeStatus instead.
 function removeUnnecessaryParensInStep(nodeStatus) {
-  let substeps = [];
   if (nodeStatus.substeps.length > 0) {
     nodeStatus.substeps.map(removeUnnecessaryParensInStep);
   }

--- a/lib/solveEquation/stepThrough.js
+++ b/lib/solveEquation/stepThrough.js
@@ -260,7 +260,7 @@ function logSteps(equationStatus) {
   if (equationStatus.substeps.length > 0) {
     // eslint-disable-next-line
     console.log('\n substeps: ');
-    equationStatus.substeps.forEach(substep => logSteps);
+    equationStatus.substeps.forEach(logSteps);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "lint": "node_modules/.bin/eslint .",
-    "test": "node_modules/.bin/mocha --recursive"
+    "test": "node_modules/.bin/mocha --recursive",
+    "setup-hooks": "ln -s ../../scripts/git-hooks/pre-commit.sh .git/hooks/pre-commit"
   },
   "repository": {
     "type": "git",

--- a/scripts/git-hooks/pre-commit.sh
+++ b/scripts/git-hooks/pre-commit.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+npm test &&
+npm run lint


### PR DESCRIPTION
Tiny PR resolving #30. There seemed to be two eslint infractions in the codebase so I fixed those in the same commit. After cloning the repository one has to run npm run setup-hooks to symlink the pre-commit hook from scripts/git-hooks/pre-commit to .git/hooks/pre-commit and it should work from there.