### PR TITLE
fix a bug where oldNode was null on every step

### DIFF
--- a/lib/node/Status.js
+++ b/lib/node/Status.js
@@ -27,12 +27,6 @@ class Status {
   hasChanged() {
     return this.changeType !== ChangeTypes.NO_CHANGE;
   }
-
-  reset() {
-    this.oldNode = null;
-    // clone so that the next step's oldNode doesn't modify this step's newNode
-    this.newNode = Status.resetChangeGroups(this.newNode);
-  }
 }
 
 Status.resetChangeGroups = function(node) {

--- a/lib/simplifyExpression/stepThrough.js
+++ b/lib/simplifyExpression/stepThrough.js
@@ -2,6 +2,7 @@
 
 const checks = require('../checks');
 const Node = require('../node');
+const Status = require('../node/Status');
 
 const arithmeticSearch = require('./arithmeticSearch');
 const basicsSearch = require('./basicsSearch');
@@ -44,8 +45,8 @@ function stepThrough(node, debug=false) {
       logSteps(nodeStatus);
     }
     steps.push(removeUnnecessaryParensInStep(nodeStatus));
-    nodeStatus.reset();
-    nodeStatus = step(nodeStatus.newNode);
+    const nextNode = Status.resetChangeGroups(nodeStatus.newNode);
+    nodeStatus = step(nextNode);
     if (iters++ === MAX_STEP_COUNT) {
       // eslint-disable-next-line
       console.error('Math error: Potential infinite loop for expression: ' +


### PR DESCRIPTION
Should fix https://github.com/socraticorg/mathsteps/issues/77. As far as I could see there was no point setting `oldNode` to `null` in `Status.reset`. The tests are still passing so I assume I didn't do something completely silly by removing it. Fingers crossed.