### PR TITLE
Use fraction numbers to avoid rounding (wip)

### DIFF
--- a/lib/equation/Equation.js
+++ b/lib/equation/Equation.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const math = require('mathjs');
+math.config({number: 'Fraction'});
 
 const clone = require('../util/clone');
 const printNode = require('../util/print');

--- a/lib/node/Creator.js
+++ b/lib/node/Creator.js
@@ -5,6 +5,8 @@
 */
 
 const math = require('mathjs');
+math.config({number: 'Fraction'});
+
 const NodeType = require('./Type');
 
 const NodeCreator = {
@@ -33,8 +35,8 @@ const NodeCreator = {
       '-', 'unaryMinus', [content]);
   },
 
-  constant (val) {
-    return new math.expression.node.ConstantNode(val);
+  constant (val, valType) {
+    return new math.expression.node.ConstantNode(val, valType);
   },
 
   symbol (name) {

--- a/lib/simplifyExpression/arithmeticSearch/index.js
+++ b/lib/simplifyExpression/arithmeticSearch/index.js
@@ -22,7 +22,7 @@ function arithmetic(node) {
   // we want to eval each arg so unary minuses around constant nodes become
   // constant nodes with negative values
   node.args.forEach((arg, i) => {
-    node.args[i] = Node.Creator.constant(arg.eval());
+    node.args[i] = Node.Creator.constant(arg.eval().toString(), "number");
   });
 
   // Only resolve division of integers if we get an integer result.
@@ -31,7 +31,7 @@ function arithmetic(node) {
     const numeratorValue = parseInt(node.args[0]);
     const denominatorValue = parseInt(node.args[1]);
     if (numeratorValue % denominatorValue === 0) {
-      const newNode = Node.Creator.constant(numeratorValue/denominatorValue);
+      const newNode = Node.Creator.constant(numeratorValue, denominatorValue);
       return Node.Status.nodeChanged(
         ChangeTypes.SIMPLIFY_ARITHMETIC, node, newNode);
     }
@@ -41,7 +41,7 @@ function arithmetic(node) {
   }
   else {
     const evaluatedValue = evaluateAndRound(node);
-    const newNode = Node.Creator.constant(evaluatedValue);
+    const newNode = Node.Creator.constant(evaluatedValue.toString(), "number");
     return Node.Status.nodeChanged(ChangeTypes.SIMPLIFY_ARITHMETIC, node, newNode);
   }
 }
@@ -49,14 +49,7 @@ function arithmetic(node) {
 // Evaluates a math expression to a constant, e.g. 3+4 -> 7 and rounds if
 // necessary
 function evaluateAndRound(node) {
-  let result = node.eval();
-  if (result < 1) {
-    result  = parseFloat(result.toPrecision(4));
-  }
-  else {
-    result  = parseFloat(result.toFixed(4));
-  }
-  return result;
+  return node.eval();
 }
 
 module.exports = search;

--- a/lib/simplifyExpression/fractionsSearch/addConstantFractions.js
+++ b/lib/simplifyExpression/fractionsSearch/addConstantFractions.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const math = require('mathjs');
+math.config({number: 'Fraction'});
+
 const clone = require('../../util/clone');
 const divideByGCD = require('./divideByGCD');
 const ChangeTypes = require('../../ChangeTypes');

--- a/lib/simplifyExpression/fractionsSearch/divideByGCD.js
+++ b/lib/simplifyExpression/fractionsSearch/divideByGCD.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const math = require('mathjs');
+math.config({number: 'Fraction'});
+
 const ChangeTypes = require('../../ChangeTypes');
 const Node = require('../../node');
 
@@ -22,8 +24,8 @@ function divideByGCD(fraction) {
     return Node.Status.noChange(fraction);
   }
 
-  const numeratorValue = parseInt(fraction.args[0].eval());
-  const denominatorValue = parseInt(fraction.args[1].eval());
+  const numeratorValue = fraction.args[0].eval();
+  const denominatorValue = fraction.args[1].eval();
 
   // The gcd is what we're dividing the numerator and denominator by.
   let gcd = math.gcd(numeratorValue, denominatorValue);

--- a/lib/simplifyExpression/functionsSearch/absoluteValue.js
+++ b/lib/simplifyExpression/functionsSearch/absoluteValue.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const math = require('mathjs');
+math.config({number: 'Fraction'});
 
 const clone = require('../../util/clone');
 const ChangeTypes = require('../../ChangeTypes');

--- a/lib/simplifyExpression/functionsSearch/nthRoot.js
+++ b/lib/simplifyExpression/functionsSearch/nthRoot.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const math = require('mathjs');
+math.config({number: 'Fraction'});
 
 const clone = require('../../util/clone');
 const ConstantFactors = require('../../factor/ConstantFactors');

--- a/lib/simplifyExpression/index.js
+++ b/lib/simplifyExpression/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const math = require('mathjs');
+math.config({number: 'Fraction'});
+
 const stepThrough = require('./stepThrough');
 
 function simplifyExpressionString(expressionString, debug=false) {

--- a/lib/simplifyExpression/simplify.js
+++ b/lib/simplifyExpression/simplify.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const math = require('mathjs');
+math.config({number: 'Fraction'});
 
 const checks = require('../checks');
 const flattenOperands = require('../util/flattenOperands');

--- a/lib/solveEquation/index.js
+++ b/lib/solveEquation/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const math = require('mathjs');
+math.config({number: 'Fraction'});
 
 const stepThrough = require('./stepThrough');
 

--- a/lib/solveEquation/stepThrough.js
+++ b/lib/solveEquation/stepThrough.js
@@ -58,8 +58,11 @@ function stepThrough(leftNode, rightNode, comparator, debug=false) {
     steps = addSimplificationSteps(steps, equation, debug);
     if (steps.length > 0) {
       const lastStep = steps[steps.length - 1];
-      equation = Equation.createEquationFromString(
-        lastStep.newEquation.print(), equation.comparator);
+      equation.leftNode = lastStep.newEquation.leftNode.clone();
+      equation.rightNode = lastStep.newEquation.rightNode.clone();
+      // console.log(left);
+      // equation = Equation.createEquationFromString(
+      //   lastStep.newEquation.print(), equation.comparator);
     }
 
     equation.leftNode = flattenOperands(equation.leftNode);

--- a/lib/util/flattenOperands.js
+++ b/lib/util/flattenOperands.js
@@ -39,7 +39,7 @@ function flattenOperands(node) {
   if (Node.Type.isConstant(node, true)) {
     // the eval() changes unary minuses around constant nodes to constant nodes
     // with negative values.
-    const constNode = Node.Creator.constant(node.eval());
+    const constNode = Node.Creator.constant(node.eval().toString(), "number");
     if (node.changeGroup) {
       constNode.changeGroup = node.changeGroup;
     }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,11 @@
+const mathsteps = require('./index');
+
+const steps = mathsteps.solveEquation('x - 3.4 = ( x - 2.5)/( 1.3)');
+
+steps.forEach(step => {
+    // console.log("before change: " + step.oldEquation);     // before change: 2 x + 2 x + x + x
+    // console.log("change: " + step.changeType);             // change: ADD_POLYNOMIAL_TERMS
+    // console.log("after change: " + step.newEquation);      // after change: 6 x
+    // console.log("# of substeps: " + step.substeps.length); // # of substeps: 3
+    console.log(step.newEquation.print());
+});


### PR DESCRIPTION
My first attempt to address https://github.com/socraticorg/mathsteps/issues/64.

Output from test.js to solve `x - 3.4 = ( x - 2.5)/( 1.3)`:
```
x - 3.4 = 0.(769230)x - 1.(923076)
(x - 3.4) - 0.(769230)x = (0.(769230)x - 1.(923076)) - 0.(769230)x
0.(230769)x - 3.4 = (0.(769230)x - 1.(923076)) - 0.(769230)x
0.(230769)x - 3.4 = -1.(923076)
(0.(230769)x - 3.4) + 3.4 = -1.(923076) + 3.4
0.(230769)x = -1.(923076) + 3.4
0.(230769)x = 1.4(769230)
(0.(230769)x) / 0.(230769) = 1.4(769230)/0.(230769)
x = 1.4(769230)/0.(230769)
x = 6.4
```

The numbers in extra brackets represent the repeating section of the decimal.  There's still lots to do, but this gives me confidence that it's doable.