### PR TITLE
Wrote helper function getRadicandNode

### DIFF
--- a/lib/simplifyExpression/functionsSearch/nthRoot.js
+++ b/lib/simplifyExpression/functionsSearch/nthRoot.js
@@ -15,7 +15,7 @@ function nthRoot(node) {
     return Node.Status.noChange(node);
   }
 
-  const radicandNode = node.args[0];
+  const radicandNode = getRadicandNode(node);
   if (Node.Type.isOperator(radicandNode)) {
     if (radicandNode.op === '^') {
       return nthRootExponent(node);
@@ -39,7 +39,7 @@ function nthRoot(node) {
 function nthRootExponent(node) {
   let newNode = clone(node);
 
-  const radicandNode = node.args[0];
+  const radicandNode = getRadicandNode(node);
   const rootNode = getRootNode(node);
   const baseNode = radicandNode.args[0];
   const exponentNode = Node.Type.isParenthesis(radicandNode.args[1]) ?
@@ -148,7 +148,7 @@ function nthRootMultiplication(node) {
 // e.g. nthRoot(2 * 9 * 5 * 12) = nthRoot(2 * 3 * 3 * 5 * 2 * 2 * 3)
 function factorMultiplicands(node) {
   const newNode = clone(node);
-  const radicandNode = node.args[0];
+  const radicandNode = getRadicandNode(node);
 
   let children = [];
   let factored = false;
@@ -200,7 +200,7 @@ function getFactorNodes(node) {
 // e.g. nthRoot(2 * 2 * 2, 2) -> nthRoot((2 * 2) * 2, 2)
 function groupTermsByRoot(node) {
   const newNode = clone(node);
-  const radicandNode = node.args[0];
+  const radicandNode = getRadicandNode(node);
   const rootNode = getRootNode(node);
   const rootValue = parseFloat(rootNode.value);
 
@@ -247,7 +247,7 @@ function groupTermsByRoot(node) {
 function convertMultiplicationToExponent(node) {
   const newNode = clone(node);
 
-  const radicandNode = node.args[0];
+  const radicandNode = getRadicandNode(node);
 
   if (Node.Type.isParenthesis(radicandNode)) {
     const child = radicandNode.content;
@@ -287,7 +287,7 @@ function convertMultiplicationToExponent(node) {
 // e.g. nthRoot(2 * x^2, 2) -> nthRoot(2) * nthRoot(x^2)
 function distributeNthRoot(node) {
   let newNode = clone(node);
-  const radicandNode = node.args[0];
+  const radicandNode = getRadicandNode(node);
   const rootNode = getRootNode(node);
 
   const children = [];
@@ -374,7 +374,7 @@ function combineRoots(node) {
 // nthRootMultiplication on the new nthRoot
 function nthRootConstant(node) {
   let newNode = clone(node);
-  const radicandNode = node.args[0];
+  const radicandNode = getRadicandNode(node);
   const rootNode = getRootNode(node);
 
   if (Negative.isNegative(radicandNode)) {
@@ -432,6 +432,15 @@ function getRootNode(node) {
   }
 
   return node.args.length === 2 ? node.args[1] : Node.Creator.constant(2);
+}
+
+// Given an nthRoot node, will return the radicand node.
+function getRadicandNode(node) {
+  if (!Node.Type.isFunction(node, 'nthRoot')) {
+    throw Error('Expected nthRoot');
+  }
+
+  return node.args[0];
 }
 
 // Sorts nodes, ordering constants nodes from smallest to largest and symbol


### PR DESCRIPTION
Implemented helper function `getRadicandNote` and called it in place of accessing `nodes.args[0]` on `nthRoot` nodes.

Fixes #34 

It looks like the other helper functions in the file (like `getRootNode`) don't have unit tests on them, but let me know if you'd like me to write them for this one!