### PR TITLE
Handle unary minus nodes that have an argument that is a parentheses …

### DIFF
--- a/lib/node/PolynomialTerm.js
+++ b/lib/node/PolynomialTerm.js
@@ -75,8 +75,7 @@ class PolynomialTerm {
     }
     else if (NodeType.isUnaryMinus(node)) {
       var arg = node.args[0];
-      if(NodeType.isParenthesis(arg))
-      {
+      if(NodeType.isParenthesis(arg)) {
         arg = arg.content;
       }
       const polyNode = new PolynomialTerm(

--- a/lib/node/PolynomialTerm.js
+++ b/lib/node/PolynomialTerm.js
@@ -74,8 +74,13 @@ class PolynomialTerm {
       }
     }
     else if (NodeType.isUnaryMinus(node)) {
+      var arg = node.args[0];
+      if(NodeType.isParenthesis(arg))
+      {
+        arg = arg.content;
+      }
       const polyNode = new PolynomialTerm(
-        node.args[0], onlyImplicitMultiplication);
+        arg, onlyImplicitMultiplication);
       this.exponent = polyNode.getExponentNode();
       this.symbol = polyNode.getSymbolNode();
       if (!polyNode.hasCoeff()) {

--- a/test/solveEquation/solveEquation.test.js
+++ b/test/solveEquation/solveEquation.test.js
@@ -61,6 +61,7 @@ describe('solveEquation for =', function () {
     // TODO: figure out what to do about errors from rounding midway through
     // this gives us 6.3995 when it should actually be 6.4 :(
     // ['x - 3.4= ( x - 2.5)/( 1.3)', 'x = 6.4']
+    ['-32 - (24x) = 34 - (2x)', 'x = -3']
   ];
   tests.forEach(t => testSolve(t[0], t[1], t[2]));
 });


### PR DESCRIPTION
Fixed a bug that was causing equations such as '-32 - (24x) = 34 - (2x)' to not be solved.