### PR TITLE
Added a script to check the installed node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "homepage": "https://github.com/socraticorg/mathsteps#readme",
   "scripts": {
     "requirements-check": "node scripts/check-version.js",
-    "preinstall": "npm run requirements-check"
+    "preinstall": "npm run requirements-check",
+    "test": "mocha --recursive"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "Step by step math solutions",
   "main": "index.js",
   "dependencies": {
-    "mathjs": "3.8.0"
+    "mathjs": "3.8.0",
+    "semver": "^5.3.0"
+  },
+  "engines": {
+    "node": ">=6.0.0"
   },
   "devDependencies": {
     "eslint": "^3.10.2",
@@ -34,5 +38,9 @@
   "bugs": {
     "url": "https://github.com/socraticorg/mathsteps/issues"
   },
-  "homepage": "https://github.com/socraticorg/mathsteps#readme"
+  "homepage": "https://github.com/socraticorg/mathsteps#readme",
+  "scripts": {
+    "requirements-check": "node scripts/check-version.js",
+    "preinstall": "npm run requirements-check"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "scripts": {
     "lint": "node_modules/.bin/eslint .",
     "test": "node_modules/.bin/mocha --recursive",
-    "setup-hooks": "ln -s ../../scripts/git-hooks/pre-commit.sh .git/hooks/pre-commit"
+    "setup-hooks": "ln -s ../../scripts/git-hooks/pre-commit.sh .git/hooks/pre-commit",
+    "requirements-check": "node scripts/check-version.js",
+    "preinstall": "npm run requirements-check"
   },
   "repository": {
     "type": "git",
@@ -38,10 +40,5 @@
   "bugs": {
     "url": "https://github.com/socraticorg/mathsteps/issues"
   },
-  "homepage": "https://github.com/socraticorg/mathsteps#readme",
-  "scripts": {
-    "requirements-check": "node scripts/check-version.js",
-    "preinstall": "npm run requirements-check",
-    "test": "mocha --recursive"
-  }
+  "homepage": "https://github.com/socraticorg/mathsteps#readme"  
 }

--- a/scripts/check-version.js
+++ b/scripts/check-version.js
@@ -1,10 +1,18 @@
+/*global process*/
+'use strict';
+
 const semver = require('semver');
 const engines = require('../package').engines;
 
 const version = engines.node;
 if (!semver.satisfies(process.version, version)) {
-  console.log(`Required node version ${version} not satisfied with current version ${process.version}.`);
+  // eslint-disable-next-line
+  console.log(`Required node version ${version} not satisfied with current ` + 
+    `version ${process.version}.`);
   process.exit(1);
-} else {
-  console.log(`Current node version ${process.version} satisfies version requirement ${version}`);
+}
+else {
+  // eslint-disable-next-line
+  console.log(`Current node version ${process.version} satisfies version ` + 
+   `requirement ${version}`);
 }

--- a/scripts/check-version.js
+++ b/scripts/check-version.js
@@ -1,0 +1,10 @@
+const semver = require('semver');
+const engines = require('../package').engines;
+
+const version = engines.node;
+if (!semver.satisfies(process.version, version)) {
+  console.log(`Required node version ${version} not satisfied with current version ${process.version}.`);
+  process.exit(1);
+} else {
+  console.log(`Current node version ${process.version} satisfies version requirement ${version}`);
+}


### PR DESCRIPTION
This should solve #82 with [this](http://stackoverflow.com/questions/29349684/how-can-i-specify-the-required-node-js-version-in-packages-json/41620850#41620850) solution proposed in the issue comments.

A script has been added in the `scripts` folder to check the current node version against the one required in `package.json` and the script execution has been bound to the `preinstall` stage in the package file itself.

Unfortunately this adds a dependency from `semver`, but I guess there is no easier way to handle version comparison than adding an external dependency.