### PR TITLE
Handle division by 0

### DIFF
--- a/lib/ChangeTypes.js
+++ b/lib/ChangeTypes.js
@@ -65,6 +65,8 @@ module.exports = {
   GROUP_TERMS_BY_ROOT: 'GROUP_TERMS_BY_ROOT',
   // e.g. x/(2/3) -> x * 3/2
   MULTIPLY_BY_INVERSE: 'MULTIPLY_BY_INVERSE',
+  // e.g. 1/0 -> 1/0
+  DIVISION_BY_ZERO: 'DIVISION_BY_ZERO',
   // e.g. x * 0 -> 0
   MULTIPLY_BY_ZERO: 'MULTIPLY_BY_ZERO',
   // e.g. 2x * 3x -> (2 * 3)(x * x)

--- a/lib/simplifyExpression/basicsSearch/handleDivisionByZero.js
+++ b/lib/simplifyExpression/basicsSearch/handleDivisionByZero.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const ChangeTypes = require('../../ChangeTypes');
+const Node = require('../../node');
+
+// If `node` is a division operation of something by 0, we return
+// a special ChangeTypes.DIVISION_BY_ZERO. The function simplifyExpression
+// will pick this up and stop processing. Returns a Node.Status object.
+function handleDivisionByZero(node) {
+  if (node.op !== '/') {
+    return Node.Status.noChange(node);
+  }
+  const denominator = node.args[1];
+  if (!Node.Type.isConstant(denominator)) {
+    return Node.Status.noChange(node);
+  }
+
+  if (parseFloat(denominator.value) === 0) {
+    return Node.Status.nodeChanged(
+      ChangeTypes.DIVISION_BY_ZERO, node, node);
+  }
+  else {
+    return Node.Status.noChange(node);
+  }
+}
+module.exports = handleDivisionByZero;

--- a/lib/simplifyExpression/basicsSearch/index.js
+++ b/lib/simplifyExpression/basicsSearch/index.js
@@ -9,6 +9,7 @@ const Node = require('../../node');
 const TreeSearch = require('../../TreeSearch');
 
 const reduceMultiplicationByZero = require('./reduceMultiplicationByZero');
+const handleDivisionByZero = require('./handleDivisionByZero');
 const reduceZeroDividedByAnything = require('./reduceZeroDividedByAnything');
 const reduceExponentByZero = require('./reduceExponentByZero');
 const removeExponentByOne = require('./removeExponentByOne');
@@ -23,6 +24,8 @@ const rearrangeCoefficient = require('./rearrangeCoefficient');
 const SIMPLIFICATION_FUNCTIONS = [
   // multiplication by 0 yields 0
   reduceMultiplicationByZero,
+  // division by zero should fail
+  handleDivisionByZero,
   // division of 0 by something yields 0
   reduceZeroDividedByAnything,
   // ____^0 --> 1

--- a/lib/simplifyExpression/stepThrough.js
+++ b/lib/simplifyExpression/stepThrough.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const checks = require('../checks');
+const ChangeTypes = require('../ChangeTypes');
 const Node = require('../node');
 const Status = require('../node/Status');
 
@@ -45,6 +46,10 @@ function stepThrough(node, debug=false) {
       logSteps(nodeStatus);
     }
     steps.push(removeUnnecessaryParensInStep(nodeStatus));
+    // Stop on division by zero
+    if (nodeStatus.changeType === ChangeTypes.DIVISION_BY_ZERO) {
+      break;
+    }
     const nextNode = Status.resetChangeGroups(nodeStatus.newNode);
     nodeStatus = step(nextNode);
     if (iters++ === MAX_STEP_COUNT) {

--- a/test/simplifyExpression/basicsSearch/handleDivisionByZero.test.js
+++ b/test/simplifyExpression/basicsSearch/handleDivisionByZero.test.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const handleDivisionByZero = require('../../../lib/simplifyExpression/basicsSearch/handleDivisionByZero');
+const testSimplify = require('./testSimplify');
+
+describe('handleDivisionByZero', function() {
+  const tests = [
+    ['1/0', '1/0'],
+    ['0/0', '0/0'],
+  ];
+  tests.forEach(t => testSimplify(t[0], t[1], handleDivisionByZero));
+});

--- a/test/simplifyExpression/oneStep.test.js
+++ b/test/simplifyExpression/oneStep.test.js
@@ -96,3 +96,15 @@ describe('simplifyDoubleUnaryMinus step actually happens', function () {
     assert.equal(steps[0].changeType, ChangeTypes.RESOLVE_DOUBLE_MINUS);
   });
 });
+
+describe('division by zero', function () {
+  it('1/(2-2) -> 1/0', function() {
+    const steps = simplifyExpression('1/(2-2)');
+    assert.equal(steps[0].changeType, ChangeTypes.SIMPLIFY_ARITHMETIC);
+    assert.equal(steps[1].changeType, ChangeTypes.DIVISION_BY_ZERO);
+  });
+  it('0/0 -> 0/0', function() {
+    const steps = simplifyExpression('0/0');
+    assert.equal(steps[0].changeType, ChangeTypes.DIVISION_BY_ZERO);
+  });
+});


### PR DESCRIPTION
addresses #29 

This PR adds a basic search strategy which generates a `DIVISION_BY_ZERO` step when encountering either `*/0` or `0/0`. In the main loop (`simplifyExpression/stepThrough.js`) we then stop the simplification process if such a step is generated (since division by zero counts as a form of error). 