### PR TITLE
Fixes #111 (nthRoot() existence check)

### DIFF
--- a/lib/checks/hasUnsupportedNodes.js
+++ b/lib/checks/hasUnsupportedNodes.js
@@ -24,7 +24,7 @@ function hasUnsupportedNodes(node) {
     return !resolvesToConstant(node.args[0]);
   }
   else if (Node.Type.isFunction(node, 'nthRoot')) {
-    return node.args.some(hasUnsupportedNodes);
+    return node.args.some(hasUnsupportedNodes) || node.args.length < 1;
   }
   else {
     return true;

--- a/test/checks/hasUnsupportedNodes.test.js
+++ b/test/checks/hasUnsupportedNodes.test.js
@@ -21,4 +21,10 @@ describe('arithmetic stepping', function () {
       checks.hasUnsupportedNodes(math.parse('x + (-5)^2 - 8*y/2')),
       false);
   });
+
+  it('nthRoot() with no args has no support', function () {
+    assert.deepEqual(
+      checks.hasUnsupportedNodes(math.parse('nthRoot()')),
+      true);
+  });
 });


### PR DESCRIPTION
Fixes #111 

Adds check that a node exists when using nthRoot, to prevent a `Cannot read property 'type' of undefined` error that results from a nonsense query such as `x = nthRoot( )`.