### PR TITLE
parentheses in performTermOperationOnExpression 

### DIFF
--- a/lib/solveEquation/EquationOperations.js
+++ b/lib/solveEquation/EquationOperations.js
@@ -220,12 +220,14 @@ function performTermOperationOnEquation(equation, op, term, changeType) {
 
 // Performs an operation of a term on an entire given expression
 function performTermOperationOnExpression(expression, op, term) {
-  const node = (Node.Type.isOperator(expression) ?
-    Node.Creator.parenthesis(expression) : expression);
-
+  if (Node.Type.isOperator(expression) &&
+    (op === '/' || op === '*' || op === '^')) {
+      var node = Node.Creator.parenthesis(expression);
+  } else {
+    var node = expression;
+  }
   term.changeGroup = 1;
   const newNode = Node.Creator.operator(op, [node, term]);
-
   return newNode;
 }
 

--- a/test/solveEquation/solveEquation.test.js
+++ b/test/solveEquation/solveEquation.test.js
@@ -128,3 +128,21 @@ describe('solveEquation errors', function() {
   ];
   tests.forEach(t => testEquationError(t[0], t[1]));
 });
+
+function testPerformTermOperationExpressionStep(equationString, outputString, step, debug=false) {
+  it(equationString + ' -> ' + outputString, (done) => {
+    const steps = solveEquation(equationString, debug);
+    assert.equal(steps[step].newEquation.print(), outputString);
+    done();
+  });
+}
+
+describe('performTermOperationOnExpression parenthesis', function() {
+  const tests = [
+    ['x + 1 = 2', 'x + 1 - 1 = 2 - 1', 0],
+    ['2y = 2x + 2', 'y = (2x + 2) / 2', 1],
+    ['x - 1 = 2', 'x - 1 + 1 = 2 + 1', 0],
+    ['y/2 = 2x + 2', 'y = (2x + 2) * 2', 1],
+  ];
+  tests.forEach(t => testPerformTermOperationExpressionStep(t[0], t[1], t[2]));
+});


### PR DESCRIPTION
Modified performTermOperationOnExpression to add parentheses only for /, *, and ^ operations per #115. Created new test function `testPerformTermOperationExpressionStep` to test the equation at a given step. 

Tests cover +, -, /, and * cases:
-  (From #115)  x + 1 = 2  ->  x + 1 - 1 = 2 - 1 
-  (From #115)  2y = 2x + 2  ->  y = (2x + 2) / 2 
- x - 1 = 2  ->  x - 1 + 1 = 2 + 1
- y/2 = 2x + 2  ->  y = (2x + 2) * 2
