### PR TITLE
dont change the change type for simplifying the left and right side for one step

### DIFF
--- a/lib/solveEquation/stepThrough.js
+++ b/lib/solveEquation/stepThrough.js
@@ -190,7 +190,6 @@ function addSimplificationSteps(steps, equation, debug=false) {
   }
   if (leftSubSteps.length === 1) {
     const step = leftSubSteps[0];
-    step.changeType = ChangeTypes.SIMPLIFY_LEFT_SIDE;
     if (debug) {
       logSteps(step);
     }
@@ -227,7 +226,6 @@ function addSimplificationSteps(steps, equation, debug=false) {
   }
   if (rightSubSteps.length === 1) {
     const step = rightSubSteps[0];
-    step.changeType = ChangeTypes.SIMPLIFY_RIGHT_SIDE;
     if (debug) {
       logSteps(step);
     }


### PR DESCRIPTION
If when simplifying the left or right side, there is only one step, we should just use the change_type of that step. Currently we change the change type to"Simplify left side" or "Simplify right side".

This is simpler and more useful