### PR TITLE
Resetting change groups when simplifying a fraction of a polynomial

### DIFF
--- a/lib/simplifyExpression/fractionsSearch/simplifyPolynomialFraction.js
+++ b/lib/simplifyExpression/fractionsSearch/simplifyPolynomialFraction.js
@@ -27,7 +27,8 @@ function simplifyPolynomialFraction(node) {
     const coefficientFraction = polyNode.getCoeffNode(); // a division node
     const newCoeffStatus = coefficientSimplifications[i](coefficientFraction);
     if (newCoeffStatus.hasChanged()) {
-      let newCoeff = newCoeffStatus.newNode;
+      // we need to reset change groups because we're creating a new node
+      let newCoeff = Node.Status.resetChangeGroups(newCoeffStatus.newNode);
       if (newCoeff.value === '1') {
         newCoeff = null;
       }


### PR DESCRIPTION
This was causing there to be two change groups in the following example
10x/5 -> 2x

The two would be a change group and the 2x would also be a change group. This is a simple fix for this, and another reason for us to look at change-groups again in the future.