### PR TITLE
fix cancel terms error

### DIFF
--- a/lib/simplifyExpression/fractionsSearch/cancelLikeTerms.js
+++ b/lib/simplifyExpression/fractionsSearch/cancelLikeTerms.js
@@ -314,7 +314,8 @@ function cancelTerms(numerator, denominator) {
       return new CancelOutStatus(numerator, denominator, false);
     }
 
-    // Sometimes the fraction reduces to a constant e.g. 6 / 2 -> 3
+    // Sometimes the fraction reduces to a constant e.g. 6 / 2 -> 3,
+    // in which case `newCoeff` (the denominator coefficient) should be null
     if (Node.Type.isConstant(reduceStatus.newNode)) {
       numerator = reduceStatus.newNode;
       newCoeff = null;
@@ -341,6 +342,8 @@ function cancelTerms(numerator, denominator) {
       return new CancelOutStatus(reduceStatus.newNode, null, true);
     }
 
+    // Sometimes the fraction reduces to a constant e.g. 6 / 2 -> 3,
+    // in which case `newCoeff` (the denominator coefficient) should be null
     if (Node.Type.isConstant(reduceStatus.newNode)) {
       numerator = reduceStatus.newNode;
       denominator = null;

--- a/lib/simplifyExpression/fractionsSearch/cancelLikeTerms.js
+++ b/lib/simplifyExpression/fractionsSearch/cancelLikeTerms.js
@@ -22,6 +22,7 @@ function cancelLikeTerms(node) {
   if (!Node.Type.isOperator(node) || node.op !== '/') {
     return Node.Status.noChange(node);
   }
+
   let newNode = clone(node);
   const numerator = newNode.args[0];
   const denominator = newNode.args[1];
@@ -30,6 +31,7 @@ function cancelLikeTerms(node) {
   if (!isMultiplicationOfTerms(numerator) &&
       !isMultiplicationOfTerms(denominator)) {
     const cancelStatus = cancelTerms(numerator, denominator);
+
     if (cancelStatus.hasChanged) {
       newNode.args[0] = cancelStatus.numerator || Node.Creator.constant(1);
       if (cancelStatus.denominator) {
@@ -291,7 +293,9 @@ function cancelTerms(numerator, denominator) {
   // case 4: the numerator is a constant and denominator is a polynomial term
   // e.g. 2 / 4x -> 1 / 2x
 
-  if (Node.Type.isConstant(numerator) && Node.PolynomialTerm.isPolynomialTerm(denominator)) {
+  if (Node.Type.isConstant(numerator)
+      && Node.Type.isOperator(denominator, '*')
+      && Node.PolynomialTerm.isPolynomialTerm(denominator)) {
     const denominatorTerm = new Node.PolynomialTerm(denominator);
 
     const coeff = denominatorTerm.getCoeffNode();

--- a/lib/simplifyExpression/fractionsSearch/cancelLikeTerms.js
+++ b/lib/simplifyExpression/fractionsSearch/cancelLikeTerms.js
@@ -290,8 +290,10 @@ function cancelTerms(numerator, denominator) {
     return new CancelOutStatus(numerator, denominator, true);
   }
 
-  // case 4: the numerator is a constant and denominator is a polynomial term
+  // case 4: the numerator is a constant and denominator is a polynomial term that has a coefficient
+  // or is multiplication node
   // e.g. 2 / 4x -> 1 / 2x
+  // e.g. ignore cases like:  2 / a and 2 / x^2
 
   if (Node.Type.isConstant(numerator)
       && Node.Type.isOperator(denominator, '*')

--- a/lib/simplifyExpression/fractionsSearch/cancelLikeTerms.js
+++ b/lib/simplifyExpression/fractionsSearch/cancelLikeTerms.js
@@ -314,8 +314,14 @@ function cancelTerms(numerator, denominator) {
       return new CancelOutStatus(numerator, denominator, false);
     }
 
-    [numerator, newCoeff] = reduceStatus.newNode.args;
-
+    // Sometimes the fraction reduces to a constant e.g. 6 / 2 -> 3
+    if (Node.Type.isConstant(reduceStatus.newNode)) {
+      numerator = reduceStatus.newNode;
+      newCoeff = null;
+    }
+    else {
+      [numerator, newCoeff] = reduceStatus.newNode.args;
+    }
     denominator = Node.Creator.polynomialTerm(variable, exponent, newCoeff);
 
     return new CancelOutStatus(numerator, denominator, true);
@@ -335,7 +341,14 @@ function cancelTerms(numerator, denominator) {
       return new CancelOutStatus(reduceStatus.newNode, null, true);
     }
 
-    [numerator, denominator] = reduceStatus.newNode.args;
+    if (Node.Type.isConstant(reduceStatus.newNode)) {
+      numerator = reduceStatus.newNode;
+      denominator = null;
+    }
+    else {
+      [numerator, denominator] = reduceStatus.newNode.args;
+    }
+
     return new CancelOutStatus(numerator, denominator, true);
   }
 

--- a/test/simplifyExpression/fractionsSearch/cancelLikeTerms.test.js
+++ b/test/simplifyExpression/fractionsSearch/cancelLikeTerms.test.js
@@ -23,6 +23,7 @@ describe('cancel like terms', function () {
     ['-x / -x', '1'],
     ['2/ (4x)', '1 / (2x)'],
     ['2/ (4x^2)', '1 / (2x^2)'],
+    ['2 a / a', '2'],
     ['(35 * nthRoot (7)) / (5 * nthRoot(5))','(7 * nthRoot(7)) / nthRoot(5)'],
   ];
 

--- a/test/simplifyExpression/fractionsSearch/cancelLikeTerms.test.js
+++ b/test/simplifyExpression/fractionsSearch/cancelLikeTerms.test.js
@@ -25,6 +25,8 @@ describe('cancel like terms', function () {
     ['2/ (4x^2)', '1 / (2x^2)'],
     ['2 a / a', '2'],
     ['(35 * nthRoot (7)) / (5 * nthRoot(5))','(7 * nthRoot(7)) / nthRoot(5)'],
+    ['3/(9r^2)', '1 / (3r^2)'],
+    ['6/(2x)', '3 / (x)']
   ];
 
   tests.forEach(t => testCancelLikeTerms(t[0], t[1]));

--- a/test/simplifyExpression/simplify.test.js
+++ b/test/simplifyExpression/simplify.test.js
@@ -125,6 +125,8 @@ describe('cancelling out', function() {
     ['((2x^3 y^2)/(-x^2 y^5))^(-2)', '(-2x * y^-3)^-2'],
     ['(1+2a)/a', '1 / a + 2'],
     ['(x ^ 4 * y + -(x ^ 2 * y ^ 2)) / (-x ^ 2 * y)', 'x^4 * -1 / (x^2) + y'],
+    // TODO: not the right answer needs to be fixed
+    ['(3 x ^ 2 + 2 x + 6) / (3 x * (x + 3))', '3x / (3x + 9) + 2 / (3x + 9) + 2 / (x^2 + 3x)']
   ];
   tests.forEach(t => testSimplify(t[0], t[1], t[2]));
 });

--- a/test/simplifyExpression/simplify.test.js
+++ b/test/simplifyExpression/simplify.test.js
@@ -123,6 +123,8 @@ describe('cancelling out', function() {
     ['(-x)/(x)', '-1'],
     ['(x)/(-x)', '-1'],
     ['((2x^3 y^2)/(-x^2 y^5))^(-2)', '(-2x * y^-3)^-2'],
+    ['(1+2a)/a', '1 / a + 2'],
+    ['(x ^ 4 * y + -(x ^ 2 * y ^ 2)) / (-x ^ 2 * y)', 'x^4 * -1 / (x^2) + y'],
   ];
   tests.forEach(t => testSimplify(t[0], t[1], t[2]));
 });

--- a/test/simplifyExpression/simplify.test.js
+++ b/test/simplifyExpression/simplify.test.js
@@ -125,8 +125,7 @@ describe('cancelling out', function() {
     ['((2x^3 y^2)/(-x^2 y^5))^(-2)', '(-2x * y^-3)^-2'],
     ['(1+2a)/a', '1 / a + 2'],
     ['(x ^ 4 * y + -(x ^ 2 * y ^ 2)) / (-x ^ 2 * y)', 'x^4 * -1 / (x^2) + y'],
-    // TODO: not the right answer needs to be fixed
-    ['(3 x ^ 2 + 2 x + 6) / (3 x * (x + 3))', '3x / (3x + 9) + 2 / (3x + 9) + 2 / (x^2 + 3x)']
+    ['6 / (2x^2)', '3 / (x^2)'],
   ];
   tests.forEach(t => testSimplify(t[0], t[1], t[2]));
 });


### PR DESCRIPTION
sentry bugs:
https://sentry.io/socratic/athena/issues/308248105/
https://sentry.io/socratic/athena/issues/308226210/

Another one:
https://sentry.io/socratic/athena/issues/308235832/

The error was because `polynomialTerms` also includes symbols and powers, which I do not want to be cancelled.