### PR TITLE
fixing a bug in nth root terms multiplication

### DIFF
--- a/lib/checks/canMultiplyLikeTermsNthRoots.js
+++ b/lib/checks/canMultiplyLikeTermsNthRoots.js
@@ -1,4 +1,5 @@
 const Node = require('../node');
+const NthRoot = require('../simplifyExpression/functionsSearch/nthRoot');
 
 // Function to check if nthRoot nodes can be multiplied
 // e.g. nthRoot(x, 2) * nthRoot(x, 2) -> true
@@ -14,9 +15,10 @@ function canMultiplyLikeTermsNthRoots(node) {
 
   // Take arbitrary root node
   const firstTerm = node.args[0];
-  const rootNode = firstTerm.args[1];
+  const rootNode = NthRoot.getRootNode(firstTerm);
 
-  return node.args.every(term => term.args[1].equals(rootNode));
+  return node.args.every(
+    term => NthRoot.getRootNode(term).equals(rootNode));
 }
 
 module.exports = canMultiplyLikeTermsNthRoots;

--- a/lib/simplifyExpression/collectAndCombineSearch/LikeTermCollector.js
+++ b/lib/simplifyExpression/collectAndCombineSearch/LikeTermCollector.js
@@ -3,6 +3,7 @@ const print = require('../../util/print');
 
 const ChangeTypes = require('../../ChangeTypes');
 const Node = require('../../node');
+const NthRoot = require('../functionsSearch/nthRoot');
 const Util = require('../../util/Util');
 
 const CONSTANT = 'constant';
@@ -228,8 +229,8 @@ function getTermsForCollectingMultiplication(node) {
 // Takes the terms dictionary and the nthRoot node, and returns an updated
 // terms dictionary.
 function addToTermsforNthRootMultiplication(terms, node) {
-  const nthRootNode = node;
-  const rootNodeValue = nthRootNode.args[1].value;
+  const rootNode = NthRoot.getRootNode(node);
+  const rootNodeValue = rootNode.value;
 
   terms = Util.appendToArrayInObject(terms, NTH_ROOT + rootNodeValue , node);
 

--- a/lib/simplifyExpression/collectAndCombineSearch/multiplyLikeTerms.js
+++ b/lib/simplifyExpression/collectAndCombineSearch/multiplyLikeTerms.js
@@ -61,7 +61,8 @@ function multiplyNthRoots(node) {
 
   // All the args at this point have the same root,
   // so we arbitrarily take the first one
-  const rootNode = NthRoot.getRootNode(node.args[0]);
+  const firstArg = node.args[0];
+  const rootNode = NthRoot.getRootNode(firstArg);
 
   newNode = Node.Creator.nthRoot(newRadicandNode, rootNode);
 

--- a/lib/simplifyExpression/collectAndCombineSearch/multiplyLikeTerms.js
+++ b/lib/simplifyExpression/collectAndCombineSearch/multiplyLikeTerms.js
@@ -6,6 +6,7 @@ const multiplyFractionsSearch = require('../multiplyFractionsSearch');
 
 const ChangeTypes = require('../../ChangeTypes');
 const Node = require('../../node');
+const NthRoot = require('../functionsSearch/nthRoot');
 
 // Multiplies a list of nodes that are polynomial or constant power like terms.
 // Returns a node.
@@ -52,15 +53,15 @@ function multiplyNthRoots(node) {
 
   let newNode = clone(node);
 
-  // Array of bases of all the nthRoot terms being multiplied
-  const radicands = node.args.map(term => term.args[0]);
+  // Array of radicands of all the nthRoot terms being multiplied
+  const radicands = node.args.map(term => NthRoot.getRadicandNode(term));
 
   // Multiply them
   const newRadicandNode = Node.Creator.operator('*', radicands);
 
   // All the args at this point have the same root,
   // so we arbitrarily take the first one
-  const rootNode = node.args[0].args[1];
+  const rootNode = NthRoot.getRootNode(node.args[0]);
 
   newNode = Node.Creator.nthRoot(newRadicandNode, rootNode);
 

--- a/lib/simplifyExpression/functionsSearch/index.js
+++ b/lib/simplifyExpression/functionsSearch/index.js
@@ -1,11 +1,11 @@
 const absoluteValue = require('./absoluteValue');
-const nthRoot = require('./nthRoot');
 
 const Node = require('../../node');
+const NthRoot = require('./nthRoot');
 const TreeSearch = require('../../TreeSearch');
 
 const FUNCTIONS = [
-  nthRoot,
+  NthRoot.nthRoot,
   absoluteValue
 ];
 

--- a/lib/simplifyExpression/functionsSearch/nthRoot.js
+++ b/lib/simplifyExpression/functionsSearch/nthRoot.js
@@ -490,4 +490,8 @@ function isMultiplicationOfEqualNodes(node) {
   return [...new Set(termStrings)].length === 1;
 }
 
-module.exports = nthRoot;
+module.exports = {
+  getRadicandNode,
+  getRootNode,
+  nthRoot,
+};

--- a/test/simplifyExpression/collectAndCombineSearch/collectAndCombineSearch.test.js
+++ b/test/simplifyExpression/collectAndCombineSearch/collectAndCombineSearch.test.js
@@ -24,6 +24,18 @@ describe('combineNthRoots multiplication', function() {
       ['(nthRoot(2 x, 2) * nthRoot(2 x, 2)) * (nthRoot(y, 4) * nthRoot(y ^ 3, 4))',
         'nthRoot(2 x * 2 x, 2) * (nthRoot(y, 4) * nthRoot(y ^ 3, 4))',
         'nthRoot(2 x * 2 x, 2) * nthRoot(y * y ^ 3, 4)'],
+    ],
+    ['nthRoot(x) * nthRoot(x)',
+      [],
+      'nthRoot(x * x, 2)'
+    ],
+    ['nthRoot(3) * nthRoot(3)',
+      [],
+      'nthRoot(3 * 3, 2)'
+    ],
+    ['nthRoot(5) * nthRoot(9x, 2)',
+      [],
+      'nthRoot(5 * 9 x, 2)'
     ]
   ];
   tests.forEach(t => testCollectAndCombineSubsteps(t[0], t[1], t[2]));

--- a/test/simplifyExpression/functionsSearch/nthRoot.test.js
+++ b/test/simplifyExpression/functionsSearch/nthRoot.test.js
@@ -1,9 +1,9 @@
-const nthRoot = require('../../../lib/simplifyExpression/functionsSearch/nthRoot');
+const NthRoot = require('../../../lib/simplifyExpression/functionsSearch/nthRoot');
 
 const TestUtil = require('../../TestUtil');
 
 function testNthRoot(exprString, outputStr) {
-  TestUtil.testSimplification(nthRoot, exprString, outputStr);
+  TestUtil.testSimplification(NthRoot.nthRoot, exprString, outputStr);
 }
 
 describe('simplify nthRoot', function () {
@@ -33,7 +33,7 @@ describe('simplify nthRoot', function () {
 
 function testNthRootSteps(exprString, outputList) {
   const lastString = outputList[outputList.length - 1];
-  TestUtil.testSubsteps(nthRoot, exprString, outputList, lastString);
+  TestUtil.testSubsteps(NthRoot.nthRoot, exprString, outputList, lastString);
 }
 
 describe('nthRoot steps', function () {


### PR DESCRIPTION
The previous code would error if you left out the root node, i.g. `nthRoot(x, 2) * nthRoot(x, 2)` worked but `nthRoot(x) * nthRoot(x)` didn't.

Instead of `node.args[1]` we should always use `getRootNode(node)`.