### PR TITLE
fix for nested functions

### DIFF
--- a/lib/util/flattenOperands.js
+++ b/lib/util/flattenOperands.js
@@ -82,6 +82,15 @@ function flattenOperands(node) {
     }
     return flattenedNode;
   }
+  else if (Node.Type.isFunction(node) && node.fn.args) {
+    // e.g. nthRoot(11)(x+y) -> nthRoot(11) * (x+y)
+    //      abs(3)(1+2) -> abs(3) * (1+2)
+    const flattenedFn = flattenOperands(node.fn);
+    const flattenedArg = flattenOperands(node.args[0]);
+    const newNode = Node.Creator.operator(
+      '*', [flattenedFn, Node.Creator.parenthesis(flattenedArg)]);
+    return newNode;
+  }
   else if (Node.Type.isFunction(node, 'abs')) {
     node.args[0] = flattenOperands(node.args[0]);
     return node;

--- a/lib/util/flattenOperands.js
+++ b/lib/util/flattenOperands.js
@@ -83,10 +83,14 @@ function flattenOperands(node) {
     return flattenedNode;
   }
   else if (Node.Type.isFunction(node) && node.fn.args) {
+    // node.fn.args will only be populated in the case where a function node is
+    // followed by a node in parenthesis
+    // mathjs parses this incorrectly; we want to convert the node to be
+    // multiplication between the function and the node in parenthesis
     // e.g. nthRoot(11)(x+y) -> nthRoot(11) * (x+y)
     //      abs(3)(1+2) -> abs(3) * (1+2)
-    const flattenedFn = flattenOperands(node.fn);
-    const flattenedArg = flattenOperands(node.args[0]);
+    const flattenedFn = flattenOperands(node.fn); // e.g. nthRoot(11)
+    const flattenedArg = flattenOperands(node.args[0]); // e.g. x+y
     const newNode = Node.Creator.operator(
       '*', [flattenedFn, Node.Creator.parenthesis(flattenedArg)]);
     return newNode;

--- a/test/util/flattenOperands.test.js
+++ b/test/util/flattenOperands.test.js
@@ -94,3 +94,17 @@ describe('subtraction', function () {
   ];
   tests.forEach(t => testFlatten(t[0], t[1]));
 });
+
+describe('flattens nested functions', function () {
+  const tests = [
+    ['nthRoot(11)(x+y)',
+      math.parse('nthRoot(11) * (x+y)')],
+    ['abs(3)(1+2)',
+      math.parse('abs(3) * (1+2)')],
+    ['nthRoot(2)(nthRoot(18)+4*nthRoot(3))',
+      math.parse('nthRoot(2) * (nthRoot(18)+4*nthRoot(3))')],
+    ['nthRoot(6,3)(10+4x)',
+      math.parse('nthRoot(6,3) * (10+4x)')]
+  ];
+  tests.forEach(t => testFlatten(t[0], t[1]));
+});


### PR DESCRIPTION
Previously, we had an issue with things like `nthRoot(x)(1+2)`. This would be parsed incorrectly, whereas `nthRoot(x) * (1+2)` would be fine. They should really be the same. This fix simply converts the former to the latter.

See broken example:

![img_0635](https://user-images.githubusercontent.com/1062275/28240354-9f9ea136-693d-11e7-88a0-c4f0bf00193a.png)
