### PR TITLE
quick fix for grouping coefficients change group

### DIFF
--- a/lib/simplifyExpression/collectAndCombineSearch/addLikeTerms.js
+++ b/lib/simplifyExpression/collectAndCombineSearch/addLikeTerms.js
@@ -186,7 +186,7 @@ function groupCoefficientsForAdding(node, termSubclass) {
     baseNode, exponentNode, sumOfCoefficents);
 
   return Node.Status.nodeChanged(
-    ChangeTypes.GROUP_COEFFICIENTS, node, newNode);
+    ChangeTypes.GROUP_COEFFICIENTS, node, newNode, false);
 }
 
 // Given a node of the form (2 + 4 + 5)x -- ie the coefficients have been


### PR DESCRIPTION
The color was off because the change group was being set on both the coefficient sum *and* the whole node, rather that just the coefficient sum.