### PR TITLE
remove unnecessary parens before solving equations

### DIFF
--- a/lib/solveEquation/stepThrough.js
+++ b/lib/solveEquation/stepThrough.js
@@ -51,9 +51,9 @@ function stepThrough(leftNode, rightNode, comparator, debug=false) {
   const MAX_STEP_COUNT = 20;
   let iters = 0;
 
-  // Remove unnecessary parenthesis here, before doing the find roots check
+  // Remove unnecessary parentheses here, before doing the find roots check
   // If we have roots, we return early and do not go through simplification,
-  // so we can't rely on that flow for parenthesis removal
+  // so we can't rely on that flow for parentheses removal
   // e.g. x^(2) = 0
   equation.leftNode = removeUnnecessaryParens(equation.leftNode);
   equation.rightNode = removeUnnecessaryParens(equation.rightNode);

--- a/lib/solveEquation/stepThrough.js
+++ b/lib/solveEquation/stepThrough.js
@@ -51,6 +51,13 @@ function stepThrough(leftNode, rightNode, comparator, debug=false) {
   const MAX_STEP_COUNT = 20;
   let iters = 0;
 
+  // Remove unnecessary parenthesis here, before doing the find roots check
+  // If we have roots, we return early and do not go through simplification,
+  // so we can't rely on that flow for parenthesis removal
+  // e.g. x^(2) = 0
+  equation.leftNode = removeUnnecessaryParens(equation.leftNode);
+  equation.rightNode = removeUnnecessaryParens(equation.rightNode);
+
   // Checks if there are roots in the original equation before we
   // do any simplification.
   // E.g. (33 + 89) (x - 99) = 0

--- a/lib/solveEquation/stepThrough.js
+++ b/lib/solveEquation/stepThrough.js
@@ -54,7 +54,7 @@ function stepThrough(leftNode, rightNode, comparator, debug=false) {
   // Remove unnecessary parentheses here, before doing the find roots check
   // If we have roots, we return early and do not go through simplification,
   // so we can't rely on that flow for parentheses removal
-  // e.g. x^(2) = 0
+  // e.g. x^(2) = 0 -> x^2 = 0
   equation.leftNode = removeUnnecessaryParens(equation.leftNode);
   equation.rightNode = removeUnnecessaryParens(equation.rightNode);
 

--- a/test/solveEquation/solveEquation.test.js
+++ b/test/solveEquation/solveEquation.test.js
@@ -87,6 +87,7 @@ describe('solveEquation for =', function () {
     ['(x - 1)(x - 5)(x + 5) = 0', 'x = [1, 5, -5]'],
     ['x^2 (x - 5)^2 = 0', 'x = [0, 0, 5, 5]'],
     ['x^2 = 0', 'x = [0, 0]'],
+    ['x^(2) = 0', 'x = [0, 0]'],
     ['(x+2)^2 -x^2 = 4(x+1)', '4 = 4'],
     // TODO: fix these cases, fail because lack of factoring support, for complex #s,
     // for taking the sqrt of both sides, etc


### PR DESCRIPTION
Previously unnecessary parens were removed when we simplified left/right sides of an equation. But now that we have this alternate "find roots" flow, that doesn't always happen. e.g. `x^(2) = 0` solves `x = 0` only, so `x` is simplified and `0` is simplified, but never `x^2`. So instead let's simplify an equation right away to be safe.