### PR TITLE
Parenthesis on both sides

### DIFF
--- a/lib/solveEquation/EquationOperations.js
+++ b/lib/solveEquation/EquationOperations.js
@@ -68,7 +68,13 @@ EquationOperations.removeSymbolFromDenominator = function(equation, symbolName) 
 // by multiplying or dividing by a symbol term.
 // TODO: support inverting functions e.g. sqrt, ^, log etc.
 EquationOperations.removeSymbolFromRightSide = function(equation, symbolName) {
-  const rightNode = equation.rightNode;
+  let rightNode = equation.rightNode;
+
+  if (Node.Type.isParenthesis(rightNode)) {
+    // if entire left node is a parenthesis, we can ignore the parenthesis
+    rightNode = rightNode.content;
+  }
+
   let symbolTerm = Symbols.getLastSymbolTerm(rightNode, symbolName);
 
   let inverseOp, inverseTerm, changeType;

--- a/test/solveEquation/solveEquation.test.js
+++ b/test/solveEquation/solveEquation.test.js
@@ -96,7 +96,8 @@ describe('solveEquation for =', function () {
     ['(3 + x) / (x^2 + 3) = 1', 'x = [0, 1]'],
     ['6/x + 8/(2x) = 10', 'x = 1'],
     ['(x+1)=4', 'x = 3'],
-    ['((x)/(4))=4', 'x = 16']
+    ['((x)/(4))=4', 'x = 16'],
+    ['(2x-12)=(x+4)', 'x = 16']
     // TODO: fix these cases, fail because lack of factoring support, for complex #s,
     // for taking the sqrt of both sides, etc
     // ['(x + y) (y + 2) = 0', 'y = -y'],


### PR DESCRIPTION
Follow-up from #250 .

In #250 I updated `isolateSymbolOnLeftSide` but neglected to also update `removeSymbolFromRightSide`.

I think because https://github.com/socraticorg/mathsteps/pull/250/files#diff-2dc14e1c8322de958fc4c52d204c30b5R42-R45, the right side (rightly) returns a node with a symbol, but because I didn't modify `removeSymbolFromRightSide`, an error was occurring when the right side couldn't handle the parenthesis node.

Thanks @evykassirer ! 
