### PR TITLE
Better handling of Unnecessary Parentheses 

### DIFF
--- a/lib/Symbols.js
+++ b/lib/Symbols.js
@@ -39,10 +39,6 @@ Symbols.getLastSymbolTerm = function(node, symbolName) {
       }
     }
   }
-  else if (Node.Type.isParenthesis(node)) {
-    return Symbols.getLastSymbolTerm(node.content, symbolName);
-  }
-
   return null;
 };
 

--- a/lib/solveEquation/EquationOperations.js
+++ b/lib/solveEquation/EquationOperations.js
@@ -128,16 +128,10 @@ EquationOperations.removeSymbolFromRightSide = function(equation, symbolName) {
 // or dividing all other symbols and constants from both sides appropriately
 // TODO: support inverting functions e.g. sqrt, ^, log etc.
 EquationOperations.isolateSymbolOnLeftSide = function(equation, symbolName) {
-  let leftNode = equation.leftNode;
-
-  if (Node.Type.isParenthesis(leftNode)) {
-    // if entire left node is a parenthesis, we can ignore the parenthesis
-    leftNode = leftNode.content;
-  }
-
+  const leftNode = equation.leftNode;
   let nonSymbolTerm = Symbols.getLastNonSymbolTerm(leftNode, symbolName);
-  let inverseOp, inverseTerm, changeType;
 
+  let inverseOp, inverseTerm, changeType;
   if (!nonSymbolTerm) {
     return EquationStatus.noChange(equation);
   }

--- a/lib/solveEquation/stepThrough.js
+++ b/lib/solveEquation/stepThrough.js
@@ -55,8 +55,8 @@ function stepThrough(leftNode, rightNode, comparator, debug=false) {
   // If we have roots, we return early and do not go through simplification,
   // so we can't rely on that flow for parentheses removal
   // e.g. x^(2) = 0 -> x^2 = 0
-  equation.leftNode = removeUnnecessaryParens(equation.leftNode);
-  equation.rightNode = removeUnnecessaryParens(equation.rightNode);
+  equation.leftNode = removeUnnecessaryParens(equation.leftNode, true);
+  equation.rightNode = removeUnnecessaryParens(equation.rightNode, true);
 
   // Checks if there are roots in the original equation before we
   // do any simplification.

--- a/test/solveEquation/solveEquation.test.js
+++ b/test/solveEquation/solveEquation.test.js
@@ -96,7 +96,8 @@ describe('solveEquation for =', function () {
     ['(3 + x) / (x^2 + 3) = 1', 'x = [0, 1]'],
     ['6/x + 8/(2x) = 10', 'x = 1'],
     ['(x+1)=4', 'x = 3'],
-    ['((x)/(4))=4', 'x = 16']
+    ['((x)/(4))=4', 'x = 16'],
+    ['(2x-12)=(x+4)', 'x = 16']
     // TODO: fix these cases, fail because lack of factoring support, for complex #s,
     // for taking the sqrt of both sides, etc
     // ['(x + y) (y + 2) = 0', 'y = -y'],


### PR DESCRIPTION
Follow up from #251 and #250 , using @xZGit's suggestion in https://github.com/socraticorg/mathsteps/pull/251#issuecomment-619899289 to just use the root argument of `removeUnnecessaryParens` 

This also undos the lib changes in #250 which no longer seem necessary